### PR TITLE
Add /elsewhere

### DIFF
--- a/pages/elsewhere.md
+++ b/pages/elsewhere.md
@@ -1,0 +1,6 @@
+---
+title: elsewhere
+description: a list of output or writings on sites other than one's own
+creator_name: Declan Chidlow
+creator_link: https://vale.rocks/elsewhere/1
+---


### PR DESCRIPTION
I feel absolutely certain that I've seen /elsewhere on slashpages.net before, but I can't see it listed, so I figured I'd submit it. I don't know if I'm going crazy or if I saw it somewhere else before, so if /elsewhere isn't an original manifestation of my mind, please feel free to remove me from being listed as 'creator'.

There is a similar concept [on the IndieWeb site](https://indieweb.org/posts-elsewhere), but it is more focused on syndication rather than being a simple list to the canonical source of that content and doesn't seem to use /elsewhere.