### PR TITLE
Add /glossary

### DIFF
--- a/pages/glossary.md
+++ b/pages/glossary.md
@@ -1,0 +1,10 @@
+---
+title: glossary
+aka:
+    - lexicon
+    - phrased
+description: a list of words you often use and their meanings, so your readers can understand them the same way you do. (or simply because you want to list your favorite words!)
+creator_name: Eltrac
+creator_link: https://www.geedea.pro/glossary/
+---
+


### PR DESCRIPTION
We have already have `/colophon` which comes from publishing, so I thought it would be cool to borrow more stuff there. So this is `/glossary` (or `/lexicon`, `/phrased`), a list of words you often use and their definition (whatever make sense to the writer). 

For now I only have an example `/glossary` page written in Chinese (`creator_link`). Hope that's OK.